### PR TITLE
Change MemoryGame/manifest.json:local_path to app/index.html

### DIFF
--- a/MemoryGame/manifest.json
+++ b/MemoryGame/manifest.json
@@ -2,7 +2,7 @@
   "name": "MemoryGame",
   "app": {
     "launch": {
-      "local_path": "index.html"
+      "local_path": "app/index.html"
     }
   },
   "description": "A memory game for older kids",


### PR DESCRIPTION
```
Currently, the game source is a submodule from 01.org,
and it contains some un-needed files under [src],
what crosswalk needed html related sources are all under [app].
It's hard to submodule only one folder which we needed,
And to make build script simple, current solution is:
Change our manifest.json to route local_path to app/index.html, to make build succeed
and the un-needed files will also be included.

For better solution need to be discussed and redesigned.
```
