### PR TITLE
Fix the flag '--version' not working when the folder 'xwalk_app_template' exists

### DIFF
--- a/android/get_xwalk_app_template.py
+++ b/android/get_xwalk_app_template.py
@@ -47,14 +47,15 @@ class GetXWalkAppTemplate(object):
     """Downloads the crosswalk package to the destination path based on the
     package url address, package prefix and package version number.
     """
+    package_name = self.package_prefix + self.version + '.zip'
+    file_path = os.path.join(self.dest_dir, package_name)
+    # We have previously downloaded, skip download.
+    if os.path.isfile(file_path):
+      return
     package_url = self.url+ '/' + self.package_prefix + self.version + '.zip'
     input_file = urllib2.urlopen(package_url)
     contents = input_file.read()
     input_file.close()
-    package_name = self.package_prefix + self.version + '.zip'
-    file_path = os.path.join(self.dest_dir, package_name)
-    if os.path.isfile(file_path):
-      os.remove(file_path)
     output_file = open(file_path, 'w')
     output_file.write(contents)
     output_file.close()


### PR DESCRIPTION
The script won't download the build tool when the folder 'xwalk_app_template' exists.
After this fix, we can switch between versions more easily.

Solution:
1: If '--version' specified for make_webapp.py
  1) If we have previously downloaded the version,
      Replace xwalk_app_template to the version
  2) If not downloaded, download it
2: If no '--version' specified, use previous one
BUG=#24
