### PR TITLE
Fix the issue for make_webapp.py failed to run on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ scripts, is written in bash (standard on many platforms, and comes
 with git on Microsoft Windows).
 
 ## Microsoft Windows support
-This is currently work-in-progress.
+Please refer to below link to setup Windows development environment:
+
+[Developing on Windows]
+(https://crosswalk-project.org/#documentation/developing-on-windows).
 
 ## License
 Crosswalk's code uses the BSD license, see our `LICENSE` file.

--- a/android/android_build_app.py
+++ b/android/android_build_app.py
@@ -27,7 +27,7 @@ def MoveApkToOut(apk_path, base_dir, app_name):
     os.remove(apk_destination)
 
   if not os.path.exists(apk_path):
-    print "Build failed"
+    print ("Build failed")
     return 3
 
   # Move the apk in xwalk_app_template to out.
@@ -41,13 +41,13 @@ def BuildApp(base_dir, app_name):
 
   # Check xwalk_app_template.
   if not os.path.exists(make_apk_script):
-    print 'Please install xwalk_app_template'
+    print ('Please install xwalk_app_template')
     return 1
 
   # Check manifest.json file.
   jsonfile = os.path.join(base_dir, app_name, 'src', 'manifest.json')
   if not os.path.exists(jsonfile):
-    print 'No manifest.json found at ' + jsonfile
+    print ('No manifest.json found at ' + jsonfile)
     return 2
 
   manifest = "--manifest=" + jsonfile
@@ -59,7 +59,7 @@ def BuildApp(base_dir, app_name):
   proc = subprocess.Popen(['python', make_apk_script, manifest, build_mode],
                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
   out, _ = proc.communicate()
-  print out
+  print (out)
   os.chdir(previous_cwd)
 
   # Move result to out.

--- a/android/get_xwalk_app_template.py
+++ b/android/get_xwalk_app_template.py
@@ -56,7 +56,7 @@ class GetXWalkAppTemplate(object):
     input_file = urllib2.urlopen(package_url)
     contents = input_file.read()
     input_file.close()
-    output_file = open(file_path, 'w')
+    output_file = open(file_path, 'wb')
     output_file.write(contents)
     output_file.close()
 
@@ -66,7 +66,7 @@ class GetXWalkAppTemplate(object):
     """
     package_name = self.package_prefix + self.version + '.zip'
     zip_file_name = os.path.join(self.dest_dir, package_name)
-    file_dir = self.dest_dir + '/' + self.package_prefix + self.version
+    file_dir = os.path.join(self.dest_dir, self.package_prefix + self.version)
     if os.path.exists(file_dir):
       shutil.rmtree(file_dir)
     try:
@@ -74,14 +74,14 @@ class GetXWalkAppTemplate(object):
       for afile in crosswalk_zip.namelist():
         crosswalk_zip.extract(afile, self.dest_dir)
       crosswalk_zip.close()
-    except zipfile.ZipError:
+    except:
       raise Exception('Error in the process of unzipping crosswalk package.')
 
   def ExtractAppTemplate(self):
     """ Extracts the specific xwalk app template to the destination directory.
     """
     self.__extract_crosswalk_package()
-    file_dir = self.dest_dir + '/' + self.file_name.split('.tar.gz')[0]
+    file_dir = os.path.join(self.dest_dir, self.file_name.split('.tar.gz')[0])
     if os.path.exists(file_dir):
       shutil.rmtree(file_dir)
     file_path = os.path.join(self.dest_dir, self.package_prefix +
@@ -96,7 +96,7 @@ def main():
   info = ('The destination directory name. Such as: '
           '--dest-dir=/')
   parser.add_option('-d', '--dest-dir', action='store', dest='dest_dir',
-                    default='./android', help=info)
+                    default='android', help=info)
   info = ('The xwalk application template version. Such as: '
           '--version=1.29.7.0')
   parser.add_option('-v', '--version', action='store', dest='version',
@@ -121,8 +121,8 @@ def main():
   crosswalk_package_prefix = 'crosswalk-'
   file_name = 'xwalk_app_template.tar.gz'
   if opts.no_downloading:
-    if not os.path.exists(dest_dir + '/' + crosswalk_package_prefix +
-                          version + '.zip'):
+    if not os.path.exists(os.path.join(dest_dir, crosswalk_package_prefix +
+                          version + '.zip')):
       raise Exception(crosswalk_package_prefix + version + '.zip' +
                       ' does not exist in %s' % dest_dir)
     else:


### PR DESCRIPTION
get_xwalk_app_template.py:
1. Change the open flag to 'wb' which will write content of downloaded zip file
    with binary mode.
2. Change some path generation issue, replace to use os.path.join.
3. There is no zipfile.ZipError class on windows, so replace with general exception.
make_webapp.py:
1. Add shell=True flag when need to call external command with subprocess.Popen.
Add the link [Developing on Windows] in README
