### PR TITLE
Enable the embedded mode by default.

### DIFF
--- a/android/android_build_app.py
+++ b/android/android_build_app.py
@@ -51,10 +51,13 @@ def BuildApp(base_dir, app_name):
     return 2
 
   manifest = "--manifest=" + jsonfile
+
+  # Enable embedded mode by default.
+  build_mode = "--mode=embedded"
   previous_cwd = os.getcwd()
   os.chdir(xwalk_app_template_path)
-  proc = subprocess.Popen(['python', make_apk_script, manifest],
-                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  proc = subprocess.Popen(['python', make_apk_script, manifest, build_mode],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
   out, _ = proc.communicate()
   print out
   os.chdir(previous_cwd)

--- a/bin/package_apks
+++ b/bin/package_apks
@@ -31,7 +31,7 @@ do
     root=$WEBAPPSCLONESDIR/$app/build/xpk
     upper_name=$(awk '/"name"/ { print $2 }' $WEBAPPSCLONESDIR/$app/package.json | tr -d '[",]')
     version=$(awk '/"version"/ { print $2 }' $WEBAPPSCLONESDIR/$app/package.json | tr -d '[",]')
-    $make_apk --fullscreen --enable-remote-debugging --package=org.org01.webapps.$name --name=_$upper_name --icon=$root/icon_128.png --app-root=$root --app-local-path=index.html
+    $make_apk --mode=embedded --fullscreen --enable-remote-debugging --package=org.org01.webapps.$name --name=_$upper_name --icon=$root/icon_128.png --app-root=$root --app-local-path=index.html
     mv _${upper_name}.apk $CROSSWALKDEMOSROOT/apks/_${upper_name}_${version}.apk
 done
 


### PR DESCRIPTION
The embedded mode is our focus now so that all web apps should be
packaged with the embedded mode by default.

BUG=https://crosswalk-project.org/jira/browse/XWALK-547
