### PR TITLE
Update manifest for samples according to spec

### DIFF
--- a/Gallery/manifest.json
+++ b/Gallery/manifest.json
@@ -1,16 +1,12 @@
 {
   "name": "Gallery",
-  "app": {
-    "launch": {
-      "local_path": "index.html"
-    }
-  },
-  "description": "[blueimp Gallery Demo](http://blueimp.github.io/Gallery/)",
-  "version": "2.10.0",
+  "start_url": "index.html",
+  "xwalk_description": "[blueimp Gallery Demo](http://blueimp.github.io/Gallery/)",
+  "xwalk_version": "2.10.0",
   "icons": {
   },
-  "permissions": [],
+  "xwalk_permissions": [],
   "required_version": "3.31.31.0",
   "plugin": [],
-  "fullscreen": "True"
+  "display": ["fullscreen"]
 }

--- a/HangOnMan/manifest.json
+++ b/HangOnMan/manifest.json
@@ -1,19 +1,15 @@
 {
   "name": "HangOnMan",
-  "app": {
-    "launch": {
-      "local_path": "app/index.html"
-    }
-  },
-  "description": "Classic Hangman Game",
-  "version": "0.0.1",
+  "start_url": "app/index.html",
+  "xwalk_description": "Classic Hangman Game",
+  "xwalk_version": "0.0.1",
   "icons": {
     "16": "icon_16.png",
     "48": "icon_64.png",
     "128": "icon_128.png"
   },
-  "permissions": [],
+  "xwalk_permissions": [],
   "required_version": "1.29.4.0",
   "plugin": [],
-  "fullscreen": "True"
+  "display": ["fullscreen"]
 }

--- a/MemoryGame/manifest.json
+++ b/MemoryGame/manifest.json
@@ -1,17 +1,13 @@
 {
   "name": "MemoryGame",
-  "app": {
-    "launch": {
-      "local_path": "app/index.html"
-    }
-  },
-  "description": "A memory game for older kids",
-  "version": "1.0",
+  "start_url": "app/index.html",
+  "xwalk_description": "A memory game for older kids",
+  "xwalk_version": "1.0",
   "icons": {
     "128": "icon_128.png"
   },
-  "permissions": [],
+  "xwalk_permissions": [],
   "required_version": "1.29.4.0",
   "plugin": [],
-  "fullscreen": "True"
+  "display": ["fullscreen"]
 }

--- a/SysApps_DeviceCapabilities/manifest.json
+++ b/SysApps_DeviceCapabilities/manifest.json
@@ -1,14 +1,10 @@
 {
   "name": "SysApps_DeviceCapabilities",
-  "app": {
-    "launch": {
-      "local_path": "index.html"
-    }
-  },
-  "description": "A demo for W3C SysApps DeviceCapabilities API.",
-  "version": "0.0.1",
+  "start_url": "index.html",
+  "xwalk_description": "A demo for W3C SysApps DeviceCapabilities API.",
+  "xwalk_version": "0.0.1",
   "icons": {
     "128": "images/icon_128.png"
   },
-  "fullscreen": "true"
+  "display": ["fullscreen"]
 }


### PR DESCRIPTION
Following http://w3c.github.io/manifest/ with
xwalk's vendor extensions.

Related BUG: XWALK-2591